### PR TITLE
Keep compatibility with Winter 1.2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,16 +1,17 @@
 # Upgrade guide
 
-- [Upgrading to 1.1 from 1.0](#upgrade-1.1)
+- [Upgrade guide](#upgrade-guide)
+  - [Upgrading To 1.1](#upgrading-to-11)
 
 <a name="upgrade-1.1"></a>
 ## Upgrading To 1.1
 
 The settings and instructions for authorizing Google have been drastically simplified. For existing accounts, you will need to generate a new key file using these steps:
 
-1. Log in to the [Google Developers Console](https://console.developers.google.com/permissions/serviceaccounts) and select the **Permissions > Service accounts** section.
-1. Click the menu dropdown icon next to the Service account
-1. Select **Create key**
-1. Choose the **Key type** of JSON.
+1. Log in to the [Google Developers Console](https://console.developers.google.com/home/dashboard) and search for **Service Accounts**
+1. If you need to create a new Service Account, click on the **Create Service Account** at the top and then add a name and click on **Create**.
+1. You should see an account in the **Service Accounts** list and click the menu in the **Actions** column and select **Manage key**.
+1. Choose the **Key type** of `JSON`.
 1. Download the file to your computer and upload it to the Winter CMS back-end settings form.
 
 The Profile ID number has also changed, follow these settings to find the new one:
@@ -18,3 +19,5 @@ The Profile ID number has also changed, follow these settings to find the new on
 1. In a new tab, navigate to the main [Google Analytics site](https://www.google.com/analytics/web/) and select the property you want to track.
 1. Click the **Admin** main menu tab again and select **View > View Settings** from the menu. *Copy to your clipboard* the Profile ID (should be a number).
 1. Paste this number in the **Analytics View/Profile ID number** field in the Winter CMS back-end settings form.
+
+> **Note**: This plugin does not support GAv4. If you are having issues creating an account, use the **Show advanced options** link in the GA Account creation and the **Create a Universal Analytics property** switch.

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "php": ">=7.2",
         "psr/cache": "^1.0",
         "composer/installers": "~1.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "google/apiclient": "^2.4"
     },
     "replace": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
-# Google Analytics integration plugin
+# Google Analytics V3 integration plugin
 
 This plugin adds Google Analytics tracking and reporting features to the [Winter CMS](https://wintercms.com).
+
+> **Note**: This plugin does not support GAv4. If you are having issues creating an account, use the **Show advanced options** link in the GA Account creation and the **Create a Universal Analytics property** switch.
 
 ## Configuration
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -18,4 +18,3 @@
   - "Rebrand to Winter.GoogleAnalytics"
   - v2.0.0/convert_data.php
 "2.0.1": "update guzzle dependency to >=6.0"
-"2.0.2": "allow guzzle dependency 7.0+"

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -18,3 +18,4 @@
   - "Rebrand to Winter.GoogleAnalytics"
   - v2.0.0/convert_data.php
 "2.0.1": "update guzzle dependency to >=6.0"
+"2.0.2": "allow guzzle dependency 7.0+"


### PR DESCRIPTION
Update dependencies to get Guzzle v6+ or v7+ depending off the Winter version.  
Add some notes to reflect Google UI changes in analytics.